### PR TITLE
feat: stopAfterInitialImport

### DIFF
--- a/src/main/java/com/malt/mongopostgresqlstreamer/StreamerApplication.java
+++ b/src/main/java/com/malt/mongopostgresqlstreamer/StreamerApplication.java
@@ -22,6 +22,9 @@ public class StreamerApplication implements ApplicationRunner {
     @Value("${mongo.connector.forcereimport:false}")
     private boolean forceReimport;
 
+    @Value("${mongo.connector.stopAfterInitialImport:false}")
+    private boolean stopAfterInitialImport;
+
     @Autowired
     private OplogStreamer oplogStreamer;
     @Autowired
@@ -56,6 +59,12 @@ public class StreamerApplication implements ApplicationRunner {
             long length = end - start;
             checkpointManager.keep(checkpoint.get());
             checkpointManager.storeImportEnd(length);
+            
+            if (stopAfterInitialImport) {
+                log.info("Stopping after first end of import as requested");
+                System.exit(0);
+                return;
+            }
         }
 
         try {


### PR DESCRIPTION
For those who uses mongodb dumps and do not need to watch for changes after that. The program able to stop after the initial import if parameters forceReimport=true and stopAfterInitialImport=true are received.